### PR TITLE
fix: add old_password field to UserSchema for password updates

### DIFF
--- a/flask_more_smorest/__init__.py
+++ b/flask_more_smorest/__init__.py
@@ -113,7 +113,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 __author__ = "Dave <david@qualisero.com>"
 __email__ = "david@qualisero.com"
 __description__ = "Enhanced Flask-Smorest blueprints with automatic CRUD operations and extensible user management"

--- a/flask_more_smorest/perms/user_schemas.py
+++ b/flask_more_smorest/perms/user_schemas.py
@@ -19,6 +19,7 @@ class UserSchema(BaseUserSchema):
     """Public user schema - extends auto-generated schema."""
 
     password = fields.Str(required=True, load_only=True)
+    old_password = fields.Str(load_only=True, load_default=None)
 
 
 class UserLoginSchema(UserSchema):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flask-more-smorest"
-version = "0.12.0"
+version = "0.12.1"
 description = "Enhanced Flask-Smorest blueprints with automatic CRUD operations"
 authors = ["Dave <david@qualisero.com>"]
 maintainers = ["Dave <david@qualisero.com>"]


### PR DESCRIPTION
UserSchema was missing `old_password` field, causing marshmallow to reject PATCH requests with 422 'Unknown field' before data reached the model's `update()` method which already handles old_password validation.

Bumps version to 0.12.1.