### PR TITLE
fix: expose is_admin and is_superadmin in UserSchema

### DIFF
--- a/flask_more_smorest/__init__.py
+++ b/flask_more_smorest/__init__.py
@@ -113,7 +113,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-__version__ = "0.12.1"
+__version__ = "0.12.2"
 __author__ = "Dave <david@qualisero.com>"
 __email__ = "david@qualisero.com"
 __description__ = "Enhanced Flask-Smorest blueprints with automatic CRUD operations and extensible user management"

--- a/flask_more_smorest/perms/user_schemas.py
+++ b/flask_more_smorest/perms/user_schemas.py
@@ -20,6 +20,8 @@ class UserSchema(BaseUserSchema):
 
     password = fields.Str(required=True, load_only=True)
     old_password = fields.Str(load_only=True, load_default=None)
+    is_admin = fields.Bool(dump_only=True)
+    is_superadmin = fields.Bool(dump_only=True)
 
 
 class UserLoginSchema(UserSchema):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flask-more-smorest"
-version = "0.12.1"
+version = "0.12.2"
 description = "Enhanced Flask-Smorest blueprints with automatic CRUD operations"
 authors = ["Dave <david@qualisero.com>"]
 maintainers = ["Dave <david@qualisero.com>"]


### PR DESCRIPTION
Adds `is_admin` and `is_superadmin` as `dump_only` fields to `UserSchema`, exposing these core `AbstractUser` properties in API responses and OpenAPI spec.

Bumps version to 0.12.2.